### PR TITLE
Show more progress info for the yt-dlp downloader

### DIFF
--- a/preload.js
+++ b/preload.js
@@ -428,7 +428,10 @@ const SharedownAPI = (() => {
         const { spawn } = require('child_process');
 
         try {
-            const videoProgBar = document.querySelector(`[data-video-id="${video.id}"]`).querySelector('.progress-bar');
+            const videoElem = document.querySelector(`[data-video-id="${video.id}"]`);
+            const progressElem = videoElem.querySelector('.progress').querySelector('span');
+            const oldTooltipTitle = progressElem.title;
+            const videoProgBar = videoElem.querySelector('.progress-bar');
             const pathAr = outFile.split(_path.sep);
             const filename = pathAr[pathAr.length - 1];
 
@@ -453,7 +456,7 @@ const SharedownAPI = (() => {
 
                 _writeLog(data.toString(), 'ytdlp');
 
-                const regex = new RegExp(/\s(\d+.\d+)%\s/);
+                const regex = new RegExp(/\s(\d+.\d+)%\s.*/);
                 const out = data.toString();
                 const isProgress = out.includes('[download]');
                 const match = out.match(regex);
@@ -481,6 +484,8 @@ const SharedownAPI = (() => {
 
                 if (ffperc > curPercInt)
                     videoProgBar.style.width = ffperc > 100 ? '100%' : `${ffperc}%`;
+
+                progressElem.setAttribute('title', match[0]);
             });
 
             ytdlp.stderr.on('data', (data) => {
@@ -488,6 +493,8 @@ const SharedownAPI = (() => {
             });
 
             ytdlp.on('close', (code) => {
+                    progressElem.setAttribute('title', oldTooltipTitle);
+
                     try {
                         if (code !== 0) {
                             _fs.rmSync(tmpFold, { force: true, recursive: true });


### PR DESCRIPTION
Firstly, thank you for the great app!

This PR shows more info about the download status like speed and ETA, as taken from yt-dlp's output.

I suck at design, so please feel free to close this and do a cleaner implementation if you like.
![tmp7](https://user-images.githubusercontent.com/41397710/140584323-1142ff5d-f2b6-4eb3-a277-c11ad15ee113.png)
